### PR TITLE
Fix handelbars warning !

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -33,7 +33,7 @@
       </div>
       {{else}}
       {{#eachSection rootNumber}}
-      {{#ifAny markup modifiers}}
+      {{#if markup}}
       <div class="styleguide-example">
         <header class="styleguide-example-header styleguide-reset">
           <h3>{{reference}} <em>{{header}}</em></h3>
@@ -76,7 +76,7 @@
         {{html description}}
       </div>
       {{/if}}
-      {{/ifAny}}
+      {{/if}}
       {{/eachSection}}
       {{/if}}
     </div>


### PR DESCRIPTION
I was not able to fix the below warning, I tried replacing the expression with triple stash and I didn't work. Can you please take a look ?

Output example:
{{html expression}} is deprecated; use HandleBars’ triple-stash instead: {{{expression}}}.

Thanks !
